### PR TITLE
Fix env loading and document missing packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ process.on('unhandledRejection', (reason, promise) => {
   console.error('⛔️ UNHANDLED REJECTION:', reason);
 });
 
-import 'dotenv/config';
+import './utils/loadEnv.js';
 import express from 'express';
 import path from 'path';
 // 如果你用 ESM，需要這兩行來取得 __dirname：

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
   "dependencies": {
     "@line/bot-sdk": "^9.9.0",
     "body-parser": "^2.2.0",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "axios": "^1.6.7",
+    "googleapis": "^132.0.0",
+    "node-fetch": "^3.3.2",
+    "openai": "^4.25.0"
   }
 }

--- a/utils/loadEnv.js
+++ b/utils/loadEnv.js
@@ -1,0 +1,23 @@
+import fs from 'fs';
+import path from 'path';
+
+export function loadEnv(filename = '.env') {
+  try {
+    const envPath = path.resolve(process.cwd(), filename);
+    const data = fs.readFileSync(envPath, 'utf8');
+    for (const line of data.split(/\r?\n/)) {
+      const match = line.match(/^([^=]+)=(.*)$/);
+      if (match) {
+        const key = match[1];
+        const value = match[2];
+        if (!process.env[key]) {
+          process.env[key] = value;
+        }
+      }
+    }
+  } catch (err) {
+    // ignore missing .env
+  }
+}
+
+loadEnv();


### PR DESCRIPTION
## Summary
- implement a tiny environment file loader
- switch index.js to use new loader instead of the missing `dotenv` module
- list all required packages in `package.json`

## Testing
- `npm test`
- `node index.js` *(fails: Cannot find package 'googleapis')*

------
https://chatgpt.com/codex/tasks/task_e_68494db732c48323a66d014241a029a2